### PR TITLE
Add Coolify deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ bun dev
 
 ### Step 3: Visit https://localhost:4001
 
+### Deploying Postgres and Electric SQL on Coolify
+
+Use the `start-coolify.sh` helper to provision the database and the Electric SQL
+backend on a Coolify instance. The script starts the containers defined in the
+repository `docker-compose.yml`, waits for Postgres to accept connections and
+then applies the Prisma schema.
+
+```bash
+# copy the environment file and adjust credentials if needed
+cp .env.example .env
+
+# start services and apply the schema
+scripts/start-coolify.sh
+
+# optionally seed the database
+SEED_DB=true scripts/start-coolify.sh
+```
+
 ## 📝 License
 
 MIT License - feel free to use this project for learning and development purposes.

--- a/scripts/start-coolify.sh
+++ b/scripts/start-coolify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start database and Electric SQL containers
+# Uses docker-compose.yml in the repo root
+
+docker compose up -d postgres electric
+
+# Wait for Postgres to accept connections
+until docker compose exec postgres pg_isready -U postgres >/dev/null 2>&1; do
+  echo "Waiting for postgres..."
+  sleep 2
+done
+
+echo "Applying Prisma schema to database"
+bun run db:push
+
+if [ "${SEED_DB:-false}" = "true" ]; then
+  echo "Seeding database..."
+  bun run db:seed
+fi
+
+printf '\nServices started successfully.\n'


### PR DESCRIPTION
## Summary
- provide helper script `start-coolify.sh` to launch Postgres and Electric SQL and apply schema
- document how to use it in README

## Testing
- `SKIP_ENV_VALIDATION=1 bun run check`
- `bun run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68413360340883228e152265530c734b