### PR TITLE
Fix sed invocation

### DIFF
--- a/start-database.sh
+++ b/start-database.sh
@@ -71,7 +71,9 @@ if [ "$DB_PASSWORD" = "password" ]; then
   fi
   # Generate a random URL-safe password
   DB_PASSWORD=$(openssl rand -base64 12 | tr '+/' '-_')
-  sed -i '' "s#:password@#:$DB_PASSWORD@#" .env
+  # Update .env with the new password. Use a portable sed command that works on
+  # both GNU and BSD variants by creating a temporary backup file.
+  sed -i.bak "s#:password@#:$DB_PASSWORD@#" .env && rm -f .env.bak
 fi
 
 $DOCKER_CMD run -d \


### PR DESCRIPTION
## Summary
- fix `start-database.sh` for portability by using a backup file when editing `.env`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841331867f48322895468a975ba5c15